### PR TITLE
RightMesh not closing when app is offline.

### DIFF
--- a/app/src/main/java/io/left/meshim/activities/ServiceConnectedActivity.java
+++ b/app/src/main/java/io/left/meshim/activities/ServiceConnectedActivity.java
@@ -52,15 +52,6 @@ public abstract class ServiceConnectedActivity extends AppCompatActivity {
     }
 
     /**
-     * Unbind from service when activity is destroyed.
-     */
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        unbindService(mConnection);
-    }
-
-    /**
      * Hide service notification when activity starts.
      */
     @Override
@@ -70,12 +61,16 @@ public abstract class ServiceConnectedActivity extends AppCompatActivity {
     }
 
     /**
-     * Show service notification when activity stops.
+     * Show service notification and unbind when activity stops.
      */
     @Override
     protected void onStop() {
         super.onStop();
         showService();
+        if (mService != null) {
+            unbindService(mConnection);
+            mService = null;
+        }
     }
 
     /**

--- a/app/src/main/java/io/left/meshim/activities/ServiceConnectedActivity.java
+++ b/app/src/main/java/io/left/meshim/activities/ServiceConnectedActivity.java
@@ -121,6 +121,8 @@ public abstract class ServiceConnectedActivity extends AppCompatActivity {
                     reconnectToService();
                 }
             }
+        } else {
+            connectToService();
         }
     }
 

--- a/app/src/main/java/io/left/meshim/services/MeshIMService.java
+++ b/app/src/main/java/io/left/meshim/services/MeshIMService.java
@@ -188,18 +188,6 @@ public class MeshIMService extends Service {
     }
 
     /**
-     * Keeps track of if this is actively bound.
-     *
-     * @param intent Intent that bound to the service
-     * @return false (don't call onRebind())
-     */
-    @Override
-    public boolean onUnbind(Intent intent) {
-        mMeshConnection.setCallback(null);
-        return false;
-    }
-
-    /**
      * Responds to events sent by the notification. Used to toggle foreground mode on/off.
      *
      * @param intent service intent.

--- a/app/src/main/java/io/left/meshim/services/MeshIMService.java
+++ b/app/src/main/java/io/left/meshim/services/MeshIMService.java
@@ -46,7 +46,6 @@ public class MeshIMService extends Service {
     private MeshIMDatabase mDatabase;
     private RightMeshController mMeshConnection;
     private Notification mServiceNotification;
-    private boolean mIsBound = false;
     private boolean mIsForeground = false;
     private int mVisibleActivities = 0;
 
@@ -185,7 +184,6 @@ public class MeshIMService extends Service {
      */
     @Override
     public IBinder onBind(Intent intent) {
-        mIsBound = true;
         return mBinder;
     }
 
@@ -197,7 +195,6 @@ public class MeshIMService extends Service {
      */
     @Override
     public boolean onUnbind(Intent intent) {
-        mIsBound = false;
         mMeshConnection.setCallback(null);
         return false;
     }
@@ -219,9 +216,11 @@ public class MeshIMService extends Service {
             action = intent.getAction();
         }
         if (action != null && action.equals(STOP_FOREGROUND_ACTION)) {
-            if (mIsBound) {
+            if (mIsForeground) {
                 stopForeground(true);
-            } else {
+                mIsForeground = false;
+            }
+            if (mVisibleActivities == 0) {
                 stopSelf();
             }
         } else if (action != null && action.equals(START_FOREGROUND_ACTION)) {


### PR DESCRIPTION
Another step in the continuing saga of the service/client/RightMesh lifecycle drama.

Since we changed the app to only unbind on activity destroy, the service was staying _alive_ (though not in the _foreground_) until the activity was swipe-killed.

This PR changes things so the it unbinds on activity stop, so that the service can come to a full stop (RightMesh included) when the app isn't in the foreground. To try to mitigate the issues we were having previously I have made the service not set the callback to null on unbind, so that the AIDL link (hopefully) isn't broken during the rapid unbind/bind process.