### PR TITLE
Revert encrypion.

### DIFF
--- a/app/src/main/java/io/left/meshim/models/User.java
+++ b/app/src/main/java/io/left/meshim/models/User.java
@@ -63,10 +63,6 @@ public class User implements Parcelable {
     @ColumnInfo(name = "Avatar")
     private int avatar;
 
-    // Whether or not we have exchanged keys with this user and can send encrypted messages.
-    @Ignore
-    private boolean isEncrypted = false;
-
     public User() {
         this("Anonymous", -1);
     }
@@ -145,14 +141,6 @@ public class User implements Parcelable {
         this.username = username;
     }
 
-    public boolean getIsEncrypted() {
-        return isEncrypted;
-    }
-
-    public void setIsEncrypted(boolean isEncrypted) {
-        this.isEncrypted = isEncrypted;
-    }
-
     /**
      * A constructor for the parcel data type.
      *
@@ -168,7 +156,6 @@ public class User implements Parcelable {
         byte[] uuid = new byte[20];
         in.readByteArray(uuid);
         this.meshId = new MeshID(uuid);
-        this.isEncrypted = (in.readInt() == 1);
     }
 
 
@@ -200,7 +187,6 @@ public class User implements Parcelable {
         dest.writeString(this.getUsername());
         dest.writeInt(this.avatar);
         dest.writeByteArray(this.meshId.getRawUuid());
-        dest.writeInt(isEncrypted ? 1 : 0);
     }
 
     /**


### PR DESCRIPTION
This PR undoes the commits adding encryption.

As implemented, both sides triggering a key exchange can result in both sides being unable to talk to each other, or trapped in a loop of key exchanges. We could have added code to make sure only one side initiates the exchange, but I opt to wait a little longer for the API to be more mature.