### PR TITLE
Missed another equals sign.

### DIFF
--- a/app/src/main/java/io/left/meshim/services/MeshIMService.java
+++ b/app/src/main/java/io/left/meshim/services/MeshIMService.java
@@ -242,7 +242,7 @@ public class MeshIMService extends Service {
                     0, intent, PendingIntent.FLAG_ONE_SHOT);
 
             NotificationCompat.Builder builder;
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 builder = new NotificationCompat.Builder(this,
                         NotificationChannel.DEFAULT_CHANNEL_ID);
             } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
Same issue resolving #30, only missed the `=` in the builder for showing message notifications, not the service notification.

Also increased the Java heap size in Gradle so that Dex can happen in a process.