### PR TITLE
update/RM-1088-Make MeshIM work with code split.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ RightMesh is a software-based, mobile mesh networking platform and protocol usin
 
 You can clone this repository and build meshIM in Android Studio. You will need your own RightMesh developer credentials, license key, and mesh port to build and run the application. Check out the [RightMesh DeveloperPortal](https://developer.rightmesh.io) to sign up and find instructions.
 
-The meshIM key is as follows and may be put in the global properties folder located in $HOME/.gradle/gradle.properties
->> rightmesh_meshim_key="0x4282c537813c21fcfb59860a89c94546564635f5"
+The official meshIM key is as follows
+>> rightmesh_meshim_key="0x4282c537813c21fcfb59860a89c94546564635f5" 
+
+This key may only be used by approved developers in order to use the library. Alternatively you may swap the key out for your own.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can clone this repository and build meshIM in Android Studio. You will need 
 The official meshIM key is as follows
 >> rightmesh_meshim_key="0x4282c537813c21fcfb59860a89c94546564635f5" 
 
-This key may only be used by approved developers in order to use the library. Alternatively you may swap the key out for your own.
+This key makes use of the official meshIM Mesh Ports and can only be used by approved developers. You may swap the key out for your own to build meshIM, however you will not be able to communicate with users running an official meshIM build.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ RightMesh is a software-based, mobile mesh networking platform and protocol usin
 
 You can clone this repository and build meshIM in Android Studio. You will need your own RightMesh developer credentials, license key, and mesh port to build and run the application. Check out the [RightMesh DeveloperPortal](https://developer.rightmesh.io) to sign up and find instructions.
 
+The meshIM key is as follows and may be put in the global properties folder located in $HOME/.gradle/gradle.properties
+>> rightmesh_meshim_key="0x4282c537813c21fcfb59860a89c94546564635f5"
+
 ## Dependencies
 
 Aside from RightMesh, meshIM uses [Gson](https://github.com/google/gson) for JSON serialization and Room for database abstraction, as well as some other Google support libraries for backwards compatibility.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,6 @@ repositories {
     jcenter()
     google()
     maven {
-        url 'https://jitpack.io'
-    }
-    maven {
         url "http://artifactory.rightmesh.io/artifactory/maven"
         credentials {
             username artifactory_app_username
@@ -46,7 +43,6 @@ android {
             }
         }
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "artifactory_app_username", "\"" + rightmesh_devportal_username + "\""
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,51 +1,42 @@
-apply plugin: 'com.android.application'
-apply plugin: 'com.google.protobuf'
-buildscript {
-    ext {
-        artifactory_app_username = "$RightMeshUsername"
-        artifactory_app_password = "$RightMeshPassword"
-        artifactory_app_key = "0x4282c537813c21fcfb59860a89c94546564635f5"
-    }
-    repositories {
-        maven {
-            url "http://research.rightmesh.io/artifactory/libs-local"
-            credentials {
-                username artifactory_app_username
-                password artifactory_app_password
-            }
-        }
-        google()
-        mavenCentral()
-        jcenter()
-    }
-    dependencies {
-        classpath 'io.left.rightmesh:rightmesh-plugin:1.6'
-    }
-
+plugins {
+    id 'com.android.application'
+    id 'io.left.rightmesh.rightmesh-plugin' version '1.8.1'
+    id 'com.google.protobuf'
 }
-apply plugin: 'io.left.rightmesh.rightmesh-plugin'
-preBuild.dependsOn("rightmesh")
 
+rightmesh {
+    appKey = rightmesh_meshim_key
+    username = rightmesh_devportal_username
+    password = rightmesh_devportal_password
+}
+
+preBuild.dependsOn("rightmesh")
 repositories {
     mavenCentral()
     jcenter()
     google()
     maven {
-        url "http://research.rightmesh.io/artifactory/libs-local"
+        url 'https://jitpack.io'
+    }
+    maven {
+        url "http://artifactory.rightmesh.io/artifactory/maven"
         credentials {
             username artifactory_app_username
             password artifactory_app_password
         }
     }
+    maven{
+        url "https://dl.bintray.com/ethereum/maven"
+    }
 }
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId 'io.left.meshim'
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 3
         versionName "0.2.1"
         multiDexEnabled true
@@ -55,19 +46,16 @@ android {
             }
         }
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    dexOptions {
-        javaMaxHeapSize "4g"
+        buildConfigField "String", "artifactory_app_username", "\"" + rightmesh_devportal_username + "\""
     }
     buildTypes {
         release {
-            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
     }
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/src/main/schemas".toString())
@@ -99,23 +87,23 @@ protobuf {
 }
 
 dependencies {
-    implementation 'android.arch.persistence.room:runtime:1.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
-    implementation 'com.android.support:support-v13:27.1.1'
+    implementation 'android.arch.persistence.room:runtime:1.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'com.android.support:support-v13:28.0.0'
 
-    annotationProcessor "android.arch.persistence.room:compiler:1.1.0"
+    annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
 
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.google.code.gson:gson:2.8.2'
-    implementation 'io.left.rightmesh:rightmesh-library:0.5.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.google.code.gson:gson:2.8.4'
+    implementation 'io.left.rightmesh:lib-rightmesh-android:0.10.0'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'android.arch.persistence.room:testing:1.1.0'
+    androidTestImplementation 'android.arch.persistence.room:testing:1.1.1'
     implementation 'com.airbnb.android:lottie:2.5.0-rc1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ repositories {
     maven {
         url "http://artifactory.rightmesh.io/artifactory/maven"
         credentials {
-            username artifactory_app_username
-            password artifactory_app_password
+            username rightmesh_devportal_username
+            password rightmesh_devportal_password
         }
     }
     maven{

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 rightmesh {
     appKey = rightmesh_meshim_key
-    username = rightmesh_devportal_username
-    password = rightmesh_devportal_password
+    username = rightmesh_build_username
+    password = rightmesh_build_password
 }
 
 preBuild.dependsOn("rightmesh")
@@ -18,8 +18,8 @@ repositories {
     maven {
         url "http://artifactory.rightmesh.io/artifactory/maven"
         credentials {
-            username rightmesh_devportal_username
-            password rightmesh_devportal_password
+            username rightmesh_build_username
+            password rightmesh_build_password
         }
     }
     maven{

--- a/app/src/main/java/io/left/meshim/controllers/RightMeshController.java
+++ b/app/src/main/java/io/left/meshim/controllers/RightMeshController.java
@@ -22,7 +22,6 @@ import io.left.meshim.models.Message;
 import io.left.meshim.models.User;
 import io.left.meshim.services.MeshIMService;
 import io.left.rightmesh.android.AndroidMeshManager;
-import io.left.rightmesh.android.MeshService;
 import io.left.rightmesh.id.MeshId;
 import io.left.rightmesh.mesh.MeshManager;
 import io.left.rightmesh.mesh.MeshManager.DataReceivedEvent;
@@ -153,7 +152,7 @@ public class RightMeshController implements MeshStateListener {
             if (meshManager != null) {
                 meshManager.stop();
             }
-        } catch (MeshService.ServiceDisconnectedException ignored) {
+        } catch (RightMeshException.RightMeshServiceDisconnectedException ignored) {
             // Error encountered shutting down service - nothing we can do from here.
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://dl.google.com/dl/android/maven2'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,15 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
+        maven {
+            url 'https://dl.google.com/dl/android/maven2'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 11 16:46:58 PDT 2018
+#Wed Nov 14 12:50:26 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,8 +10,8 @@ pluginManagement.repositories {
     maven {
         url 'https://artifactory.rightmesh.io/artifactory/maven'
         credentials {
-            username rightmesh_artifactory_username
-            password rightmesh_artifactory_password
+            username rightmesh_build_username
+            password rightmesh_build_password
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
 include ':app'
+pluginManagement.repositories {
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
+    google()
+    jcenter()
+    mavenCentral()
+    mavenLocal()
+    maven {
+        url 'https://artifactory.rightmesh.io/artifactory/maven'
+        credentials {
+            username rightmesh_artifactory_username
+            password rightmesh_artifactory_password
+        }
+    }
+}


### PR DESCRIPTION
  - Several dependency updates
  - Removal of minify disabled being false along with
  - Used Ben's layout for using the plugin requires data be added to the settings.gradle file
also changed the javaMaxHeapSize "4g"
  - removed the application key which is now stored in the global properties folder

Something to likely be done here is specify the parameters to be specified in the properties folder such as the username, password, and app key